### PR TITLE
Tailor setup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,15 @@ tuleap_org_name: Tuleap
 # Usually the fqdn of the server
 # Default: the server ip
 tuleap_domain: "{{ ansible_eth0['ipv4']['address'] }}"
+
+tuleap_packages:
+  - tuleap-install
+  - tuleap-core-subversion
+  - tuleap-plugin-agiledashboard
+  - tuleap-plugin-graphontrackers
+  - tuleap-theme-flamingparrot
+  - tuleap-documentation
+  - tuleap-customization-default
+  - restler-api-explorer
+  - php-markdown
+  - tuleap-plugin-ldap

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,0 +1,14 @@
+#
+# Tuleap install pre-requisites
+
+- name: Setup epel
+  yum: name=epel-release
+
+- name: Install pre-requistes packages
+  yum: name="{{item}}"
+  with_items:
+   - php-pecl-apc
+   - mysql-server
+
+- name: Start mysql
+  service: name=mysqld state=started

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,17 +1,6 @@
 # Install tuleap
 #
 
-- name: Install Tuleap repository
-  template:
-    src:   tuleap.repo.j2
-    dest:  /etc/yum.repos.d/tuleap.repo
-    owner: root
-    group: root
-    mode:  0644
-
-- name: Install Tuleap
-  yum: name=tuleap-all enablerepo=rpmforge-extras  
-
 # We are using the raw module here because of passwords generated with /dev/urandom :-(
 - name: Configure Tuleap
   raw: /usr/share/tuleap-install/setup.sh --sys-default-domain="{{tuleap_domain}}" --sys-org-name="{{tuleap_org_name}}" --sys-long-org-name="{{tuleap_org_name}}" 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,22 +2,22 @@
 # tasks file for tuleap
 - include_vars: "{{ tuleap_version }}.yml"
 
-- include: rpmforge.yml
+- include: dependencies.yml
 
-- name: Check if tuleap is installed
-  command: rpm -q tuleap-all
-  ignore_errors: yes
-  register: tuleap_is_installed
+- include: packages.yml
+
+- stat: path=/etc/tuleap/conf/local.inc
+  register: tuleap_conf_file
   tags:
     - tuleap-update
     - tuleap-install
 
 - include: install.yml
-  when: tuleap_is_installed.rc != 0
+  when: tuleap_conf_file.stat.exists == False
   tags:
     - tuleap-install
 
 - include: update.yml
-  when: tuleap_is_installed.rc == 0
+  when: tuleap_conf_file.stat.exists == True
   tags: 
     - tuleap-update

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,0 +1,13 @@
+# Install Tuleap RPMs
+
+- name: Install Tuleap repository
+  template:
+    src:   tuleap.repo.j2
+    dest:  /etc/yum.repos.d/tuleap.repo
+    owner: root
+    group: root
+    mode:  0644
+
+- name: Install Tuleap
+  yum: name={{ item }}
+  with_items: "{{ tuleap_packages }}"

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -2,7 +2,7 @@
 #
 
 - name: Update Tuleap
-  command: yum update tuleap-* --enablerepo=rpmforge-extras -y
+  command: yum update tuleap-* -y
   notify: restart apache
 
 - name: Forgeupgrade


### PR DESCRIPTION
- No longer depend on tuleap-all (+flexibility)
- Separate package install and configuration

Compared to tuleap-all install we should probably add some other packages:
- tuleap-plugin-mediawiki and php-mediawiki-tuleap-123
- tuleap-plugin-git-gitolite3 (/!\ with retro-compatibility with default g2 install)

And... IM is no longer installed ;)