### PR TITLE
SELinux configuration + minor syntax fixes

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,5 @@
 ---
-# handlers file for tuleap
-#
-#
+# Tuleap handlers
 
 - name: forgeupgrade
   shell: /usr/lib/forgeupgrade/bin/forgeupgrade --config=/etc/tuleap/forgeupgrade/config.ini update
@@ -12,5 +10,3 @@
 
 - name: restart tuleap
   service: name=tuleap state=restarted
-
-

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,6 @@
 
 - name: forgeupgrade
   shell: /usr/lib/forgeupgrade/bin/forgeupgrade --config=/etc/tuleap/forgeupgrade/config.ini update
-  notify: restart tuleap
 
 - name: restart apache
   service: name=httpd state=restarted

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,6 +1,11 @@
 ---
 # Install Tuleap prerequisites
 
+- name: Check SELinux policy
+  command: getenforce
+  register: se_status
+  failed_when: "se_status.stdout not in ('Disabled', 'Permissive')"
+
 - name: Setup epel
   yum: name=epel-release state="{{ tuleap_packages_state }}"
 

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,11 +1,11 @@
-#
-# Tuleap install pre-requisites
+---
+# Install Tuleap prerequisites
 
 - name: Setup epel
-  yum: name=epel-release state="{{tuleap_packages_state}}"
+  yum: name=epel-release state="{{ tuleap_packages_state }}"
 
-- name: Install pre-requistes packages
-  yum: name="{{item}}" state="{{tuleap_packages_state}}"
+- name: Install prerequisite packages
+  yum: name="{{ item }}" state="{{ tuleap_packages_state }}"
   with_items:
    - php-pecl-apc
    - mysql-server

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks file for tuleap
+# Main Tuleap task list
 - include_vars: "{{ tuleap_version }}.yml"
 
 - include: dependencies.yml
@@ -12,4 +12,3 @@
 
 - include: setup.yml
   when: tuleap_conf_file.stat.exists == False
-

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,3 +1,4 @@
+---
 # Install Tuleap RPMs
 
 - name: Install Tuleap repository

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,9 +1,9 @@
-# Install tuleap
-#
+---
+# Install Tuleap
 
 # We are using the raw module here because of passwords generated with /dev/urandom :-(
 - name: Setup Tuleap
-  raw: /usr/share/tuleap-install/setup.sh --sys-default-domain="{{tuleap_domain}}" --sys-org-name="{{tuleap_org_name}}" --sys-long-org-name="{{tuleap_org_name}}" 
+  raw: /usr/share/tuleap-install/setup.sh --sys-default-domain="{{ tuleap_domain }}" --sys-org-name="{{ tuleap_org_name }}" --sys-long-org-name="{{ tuleap_org_name }}"
   notify: 
     - restart apache
     - restart tuleap

--- a/templates/tuleap.repo.j2
+++ b/templates/tuleap.repo.j2
@@ -1,6 +1,5 @@
 [Tuleap]
 name=Tuleap
-baseurl="{{tuleap_baseurl}}"
+baseurl="{{ tuleap_baseurl }}"
 enabled=1
 gpgcheck=0
-

--- a/vars/master.yml
+++ b/vars/master.yml
@@ -1,1 +1,2 @@
+---
 tuleap_baseurl: http://ci.tuleap.net/yum/tuleap/rhel/6/dev/$basearch

--- a/vars/stable.yml
+++ b/vars/stable.yml
@@ -1,1 +1,2 @@
+---
 tuleap_baseurl: https://tuleap.net/pub/tuleap/yum/rhel/6/stable/$basearch


### PR DESCRIPTION
Thanks for maintaining this Ansible role, it's proven very useful to test data migration across different Tuleap versions ;-)

Added:
- Check SELinux configuration, fail the role if not set to `Disabled` or `Permissive`

Changed:
- Harmonize YAML syntax

Fixed:
- Remove unneeded handler notification

See:
- https://docs.ansible.com/ansible/YAMLSyntax.html
- https://docs.ansible.com/ansible/playbooks_intro.html#handlers-running-operations-on-change
- http://doc-en.tuleap.net/en/latest/installation-guide/full-installation.html
- https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security-Enhanced_Linux/sect-Security-Enhanced_Linux-Working_with_SELinux-Changing_SELinux_Modes.html
- https://docs.ansible.com/ansible/selinux_module.html