### PR TITLE
Setup checks and adjustments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,6 @@ tuleap_domain: "{{ ansible_eth0['ipv4']['address'] }}"
 # by most common services
 tuleap_packages:
   - tuleap
-  - tuleap-install
   - tuleap-core-subversion
   - tuleap-plugin-agiledashboard
   - tuleap-plugin-graphontrackers

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,6 +1,12 @@
 ---
 # Install Tuleap
 
+# Fail here if we do not have valid DNS, otherwise the setup script will just stall.
+- name: Set DNS variable
+  command: dig {{ tuleap_domain }} +short
+  register: dnscheck
+  failed_when: "dnscheck.stdout == ''"
+
 # We are using the raw module here because of passwords generated with /dev/urandom :-(
 - name: Setup Tuleap
   raw: /usr/share/tuleap-install/setup.sh --sys-default-domain="{{ tuleap_domain }}" --sys-org-name="{{ tuleap_org_name }}" --sys-long-org-name="{{ tuleap_org_name }}"

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,6 +1,11 @@
 ---
 # Install Tuleap
 
+- name: Install tuleap install scripts
+  yum:
+    name: tuleap-install
+    state: "{{ tuleap_packages_state }}"
+
 # Fail here if we do not have valid DNS, otherwise the setup script will just stall.
 - name: Set DNS variable
   command: dig {{ tuleap_domain }} +short
@@ -13,3 +18,8 @@
   notify: 
     - restart apache
     - restart tuleap
+
+- name: Remove tuleap install scripts
+  yum:
+    name: tuleap-install
+    state: absent


### PR DESCRIPTION
Hi,
Had an issue when running this role with a domain that was not registered in DNS (only in hosts file) and sat there for quite some time before realizing the setup script asks for confirmation when the domain is not found in the DNS.

Added a check to fail if the domain is not found in DNS, and also adjusted the setup to install and remove the install package automatically when running the setup script.