### PR TITLE
Test the module with Molecule

### DIFF
--- a/.github/workflows/Molecule_Test.yml
+++ b/.github/workflows/Molecule_Test.yml
@@ -1,0 +1,29 @@
+name: Test with Molecule
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2.1.4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+      - name: Test with molecule
+        run: |
+          cd tests/
+          molecule test

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -38,4 +38,4 @@
 - name: restart mysql
   systemd: 
     name: rh-mysql57-mysqld
-    state: reloaded
+    state: restarted

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+molecule[ansible,docker,lint]==3.1.5

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,3 +21,4 @@
   when: tuleap_conf_file.stat.exists == False
 
 - include: letsencrypt_cert.yml
+  when: tuleap_generate_le_cert == True

--- a/tests/molecule/default/converge.yml
+++ b/tests/molecule/default/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: ../../../../
+  vars:
+      tuleap_fqdn:             localhost
+      tuleap_admin_email:      admin@tuleap.example.com
+      tuleap_packages_state:   present
+      tuleap_generate_le_cert: False

--- a/tests/molecule/default/molecule.yml
+++ b/tests/molecule/default/molecule.yml
@@ -1,0 +1,18 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: centos:7
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/tests/molecule/default/prepare.yml
+++ b/tests/molecule/default/prepare.yml
@@ -1,0 +1,29 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+  - name: Install libselinux-python
+    package:
+      name: libselinux-python
+      state: present
+  - name: Install selinux-policy
+    package:
+      name: selinux-policy
+      state: present
+  - name: Install postfix
+    package:
+      name: postfix
+      state: present
+  - name: Bind postfix only on IPv4
+    replace:
+      path: /etc/postfix/main.cf
+      regexp: 'inet_interfaces = localhost'
+      replace: 'inet_interfaces = 127.0.0.1'
+  - name: Install OpenSSH server
+    package:
+      name: openssh-server
+      state: present
+  - name: Start sshd
+    systemd: 
+      name: sshd 
+      state: started

--- a/tests/molecule/default/verify.yml
+++ b/tests/molecule/default/verify.yml
@@ -1,0 +1,12 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Check if Tuleap homepage is up
+    uri:
+      url: https://localhost/
+      return_content: yes
+      validate_certs: false
+    register: this
+    failed_when: "'Tuleap Community Edition' not in this.content"


### PR DESCRIPTION
Molecule [0] is a tool designed to ease the development and testing of
Ansible roles. In our situation it will help us making sure the playbook
is usable. The playbook is tested against a local Docker container.

Two changes have been made on the module:
 * the `tuleap_generate_le_cert` variable is now taken into account (it
   was needed to run the test locally)
 * the handler of the MySQL server has been changed from `reloaded` to
   `restarted` as the MySQL service does not have a reload target.

[0] https://github.com/ansible-community/molecule