### PR TITLE
Add SSH to the list of services that should be accessible

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ mysql_root_password: "{{ lookup('password', '.mysql_secret.' + tuleap_fqdn + ' l
 tuleap_admin_email: "admin@{{ tuleap_fqdn }}"
 
 tuleap_network_ports:
+  - ssh
   - http
   - https
 


### PR DESCRIPTION
By default, the Git plugin is installed and this service uses the SSH
service as such it seems reasonnable to also add SSH to the list of
allowed services like HTTP and HTTPS.