### PR TITLE
Fix installation crash when the generated MySQL root password starts with a -

### DIFF
--- a/tasks/install-mysql-server.yml
+++ b/tasks/install-mysql-server.yml
@@ -15,4 +15,4 @@
 
 - name: Change mysql root password
   shell: |
-    scl enable rh-mysql57 "mysqladmin -u root password {{ mysql_root_password }}"
+    /opt/rh/rh-mysql57/root/usr/bin/mysql -u root -NBe 'ALTER USER root@localhost IDENTIFIED WITH mysql_native_password BY {{ mysql_root_password | to_json(ensure_ascii=False) }}; FLUSH PRIVILEGES;';

--- a/tasks/letsencrypt_cert.yml
+++ b/tasks/letsencrypt_cert.yml
@@ -6,7 +6,7 @@
     state: latest
 
 - name: Request certificate
-  command: /usr/bin/certbot --nginx certonly -d {{ tuleap_fqdn }} -m {{ tuleap_admin_email }} -n --agree-tos
+  command: /usr/bin/certbot --nginx certonly -d {{ tuleap_fqdn | quote }} -m {{ tuleap_admin_email | quote }} -n --agree-tos
   notify: restart nginx
 
 - name: Cron job for certbot is installed


### PR DESCRIPTION
This contribution also takes care of adding the missing escaping in the letsencrypt_cert task.