### PR TITLE
Remove usage of /usr/share/tuleap/tools/utils/php73/run.php

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,9 +4,6 @@
 - name: forgeupgrade
   shell: /usr/lib/forgeupgrade/bin/forgeupgrade --config=/etc/tuleap/forgeupgrade/config.ini update
 
-- name: run.php
-  shell: /usr/share/tuleap/tools/utils/php73/run.php --module=nginx
-
 - name: site-deploy
   shell: tuleap-cfg site-deploy
 

--- a/tasks/tuleap_packages.yml
+++ b/tasks/tuleap_packages.yml
@@ -14,7 +14,6 @@
     update_cache: yes
   notify:
     - forgeupgrade
-    - run.php
     - site-deploy
     - restart apache
     - restart nginx


### PR DESCRIPTION
The `tuleap site-deploy` command now covers all the configuration.
The tools/utils/php73/run.php script has been removed in [git #tuleap/stable/c6ee130614bd22c3b6efefd9bab41f4eeb5d4aad](https://tuleap.net/plugins/git/tuleap/tuleap/stable?a=commit&h=c6ee130614bd22c3b6efefd9bab41f4eeb5d4aad).

Part of [request #20938](https://tuleap.net/plugins/tracker/?aid=20938): Add support of PHP 7.4