### PR TITLE
Stop testing on Python 3.6 and 3.7, add 3.10

### DIFF
--- a/.github/workflows/Molecule_Test.yml
+++ b/.github/workflows/Molecule_Test.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@d09bd5e6005b175076f227b13d9730d56e9dcfcb
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
Recent version of Molecule do not support Python 3.6 and 3.7 anymore.