### PR TITLE
Verify using the API instead of the footer of the homepage

### DIFF
--- a/tests/molecule/default/verify.yml
+++ b/tests/molecule/default/verify.yml
@@ -3,9 +3,9 @@
   hosts: all
   gather_facts: false
   tasks:
-  - name: Check if Tuleap homepage is up
+  - name: Check if Tuleap API is up
     uri:
-      url: https://localhost/
+      url: https://localhost/api/version
       return_content: yes
       validate_certs: false
     register: this


### PR DESCRIPTION
Part of request #29205: Remove irrelevant/broken links from Tuleap